### PR TITLE
Fix typo and pre-create data dirs for Dev Container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 	"mounts": [
 		"source=${localWorkspaceFolder},target=/workspaces,type=bind",
 		"source=${localWorkspaceFolder}/mysql/data,target=/mysql/data,type=bind",
-		"source=${localWorkspaceFolder}/mysql/config,target=/redis/data,type=bind"
+		"source=${localWorkspaceFolder}/redis/data,target=/redis/data,type=bind"
 	],
 	"runArgs": [
 		"-p", "90:80", 

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -35,6 +35,9 @@ Starting a new project? Use this pre-built image:
    ```bash
    # Create .devcontainer directory
    mkdir -p .devcontainer
+
+   # Create mysql and redis directory
+   mkdir -p ./mysql/data && mkdir -p ./redis/data
    
    # Download devcontainer.json from GitHub
    curl -o .devcontainer/devcontainer.json https://raw.githubusercontent.com/eimg/fairway-dev-container/main/.devcontainer/devcontainer.json

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Starting a new project? Use the pre-built image from Docker Hub:
    ```bash
    # Create .devcontainer directory
    mkdir -p .devcontainer
+
+   # Create mysql and redis directory
+   mkdir -p ./mysql/data && mkdir -p ./redis/data
    
    # Download devcontainer.json from GitHub
    curl -o .devcontainer/devcontainer.json https://raw.githubusercontent.com/eimg/fairway-dev-container/main/.devcontainer/devcontainer.json


### PR DESCRIPTION
# Fix typo and pre-create data dirs for Dev Container

## Description

This PR resolves an issue where the Dev Container setup would fail due to missing host bind-mount directories. It also corrects a typo in the mount configuration.

## Changes Made

- Fixed mount syntax typo in `devcontainer.json`
- Documented required pre-created directories to avoid Docker mount errors:
  - `./mysql/data`
  - `./redis/data`

## Usage Notes

Ensure the required data directories exist **before launching the Dev Container**:

```bash
mkdir -p ./mysql/data
mkdir -p ./redis/data
